### PR TITLE
Add phase-one performance guardrails

### DIFF
--- a/.github/workflows/perf-regression.yml
+++ b/.github/workflows/perf-regression.yml
@@ -110,7 +110,7 @@ jobs:
                   "base_samples": medians("base", "flat", lambda data: data["ingest_seconds"]),
                   "head_samples": medians("head", "flat", lambda data: data["ingest_seconds"]),
                   "relative_budget": 0.05,
-                  "absolute_budget": 0.10,
+                  "absolute_budget": 0.01,
               },
           ]
           first_upsert = load("base", "upsert", 1)
@@ -126,7 +126,7 @@ jobs:
                           "head", "upsert", lambda data, size=size: data["updates"][size]["median_ms"]
                       ),
                       "relative_budget": 0.10,
-                      "absolute_budget": 1.0,
+                      "absolute_budget": 0.10,
                   }
               )
 

--- a/.github/workflows/perf-regression.yml
+++ b/.github/workflows/perf-regression.yml
@@ -1,0 +1,122 @@
+name: Performance Regression Warning
+
+on:
+  workflow_dispatch:
+  pull_request:
+    types:
+      - labeled
+
+permissions:
+  contents: read
+
+jobs:
+  compare:
+    if: github.event_name == 'workflow_dispatch' || github.event.label.name == 'perf-check'
+    runs-on: ubuntu-latest
+    env:
+      RAYON_NUM_THREADS: "4"
+      PIP_DISABLE_PIP_VERSION_CHECK: "1"
+    steps:
+      - name: Check out base revision
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.repository.default_branch }}
+          path: base
+      - name: Check out candidate revision
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+          path: head
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+      - name: Install base revision
+        run: |
+          python -m venv base/.venv
+          base/.venv/bin/python -m pip install --upgrade pip
+          base/.venv/bin/python -m pip install --config-settings=maturin.build-args=--locked ./base
+      - name: Install candidate revision
+        run: |
+          python -m venv head/.venv
+          head/.venv/bin/python -m pip install --upgrade pip
+          head/.venv/bin/python -m pip install --config-settings=maturin.build-args=--locked ./head
+      - name: Run base benchmarks
+        run: |
+          mkdir -p artifacts
+          base/.venv/bin/python base/benchmarks/flat_search_bench.py \
+            --rows 100000 --dim 64 --batch-size 25000 --warmups 5 --trials 10 \
+            --output artifacts/base-flat.json
+          base/.venv/bin/python base/benchmarks/upsert_bench.py \
+            --rows 100000 --dim 64 --ingest-batch-size 25000 --trials 5 \
+            --output artifacts/base-upsert.json
+      - name: Compare candidate benchmarks
+        id: candidate
+        continue-on-error: true
+        run: |
+          status=0
+          head/.venv/bin/python head/benchmarks/flat_search_bench.py \
+            --rows 100000 --dim 64 --batch-size 25000 --warmups 5 --trials 10 \
+            --baseline artifacts/base-flat.json --max-regression 0.05 \
+            --output artifacts/head-flat.json || status=1
+          head/.venv/bin/python head/benchmarks/upsert_bench.py \
+            --rows 100000 --dim 64 --ingest-batch-size 25000 --trials 5 \
+            --baseline artifacts/base-upsert.json --max-regression 0.10 \
+            --output artifacts/head-upsert.json || status=1
+          exit "$status"
+      - name: Write performance summary
+        if: always()
+        env:
+          CANDIDATE_OUTCOME: ${{ steps.candidate.outcome }}
+        run: |
+          head/.venv/bin/python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          root = Path("artifacts")
+          base_flat = json.loads((root / "base-flat.json").read_text())
+          head_flat = json.loads((root / "head-flat.json").read_text())
+          base_upsert = json.loads((root / "base-upsert.json").read_text())
+          head_upsert = json.loads((root / "head-upsert.json").read_text())
+
+          def change(current, baseline):
+              return current / baseline - 1.0
+
+          lines = [
+              "## Performance comparison",
+              "",
+              f"Candidate comparison step: **{os.environ['CANDIDATE_OUTCOME']}**",
+              "",
+              "| Case | Base | Candidate | Change | Warning budget |",
+              "|---|---:|---:|---:|---:|",
+              (
+                  "| Flat search median | "
+                  f"{base_flat['median_ms']:.3f} ms | {head_flat['median_ms']:.3f} ms | "
+                  f"{change(head_flat['median_ms'], base_flat['median_ms']):+.2%} | +5% |"
+              ),
+              (
+                  "| Flat ingest | "
+                  f"{base_flat['ingest_seconds']:.3f} s | {head_flat['ingest_seconds']:.3f} s | "
+                  f"{change(head_flat['ingest_seconds'], base_flat['ingest_seconds']):+.2%} | +5% |"
+              ),
+          ]
+          for size in sorted(base_upsert["updates"], key=int):
+              before = base_upsert["updates"][size]["median_ms"]
+              after = head_upsert["updates"][size]["median_ms"]
+              lines.append(
+                  f"| Upsert {size} row(s) | {before:.3f} ms | {after:.3f} ms | "
+                  f"{change(after, before):+.2%} | +10% |"
+              )
+          with open(os.environ["GITHUB_STEP_SUMMARY"], "a", encoding="utf-8") as summary:
+              summary.write("\n".join(lines) + "\n")
+          PY
+      - name: Upload benchmark artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: performance-comparison
+          path: artifacts/
+          if-no-files-found: error

--- a/.github/workflows/perf-regression.yml
+++ b/.github/workflows/perf-regression.yml
@@ -12,8 +12,10 @@ permissions:
 jobs:
   compare:
     if: github.event_name == 'workflow_dispatch' || github.event.label.name == 'perf-check'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
     env:
+      BENCH_ROUNDS: "3"
       RAYON_NUM_THREADS: "4"
       PIP_DISABLE_PIP_VERSION_CHECK: "1"
     steps:
@@ -33,6 +35,18 @@ jobs:
           python-version: "3.11"
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
+      - name: Record runner profile
+        run: |
+          mkdir -p artifacts
+          {
+            echo "runner_image=ubuntu-24.04"
+            echo "rayon_threads=$RAYON_NUM_THREADS"
+            uname -a
+            lscpu
+            free -h
+            python --version
+            rustc --version
+          } > artifacts/runner-info.txt
       - name: Install base revision
         run: |
           python -m venv base/.venv
@@ -43,29 +57,115 @@ jobs:
           python -m venv head/.venv
           head/.venv/bin/python -m pip install --upgrade pip
           head/.venv/bin/python -m pip install --config-settings=maturin.build-args=--locked ./head
-      - name: Run base benchmarks
+      - name: Run alternating benchmark rounds
         run: |
-          mkdir -p artifacts
-          base/.venv/bin/python base/benchmarks/flat_search_bench.py \
-            --rows 100000 --dim 64 --batch-size 25000 --warmups 5 --trials 10 \
-            --output artifacts/base-flat.json
-          base/.venv/bin/python base/benchmarks/upsert_bench.py \
-            --rows 100000 --dim 64 --ingest-batch-size 25000 --trials 5 \
-            --output artifacts/base-upsert.json
-      - name: Compare candidate benchmarks
+          for round in $(seq 1 "$BENCH_ROUNDS"); do
+            if (( round % 2 == 1 )); then
+              order=(base head)
+            else
+              order=(head base)
+            fi
+            for revision in "${order[@]}"; do
+              "$revision/.venv/bin/python" "$revision/benchmarks/flat_search_bench.py" \
+                --rows 100000 --dim 64 --batch-size 25000 --warmups 5 --trials 10 \
+                --output "artifacts/$revision-flat-$round.json"
+              "$revision/.venv/bin/python" "$revision/benchmarks/upsert_bench.py" \
+                --rows 100000 --dim 64 --ingest-batch-size 25000 --trials 5 \
+                --output "artifacts/$revision-upsert-$round.json"
+            done
+          done
+      - name: Evaluate performance budgets
         id: candidate
         continue-on-error: true
         run: |
-          status=0
-          head/.venv/bin/python head/benchmarks/flat_search_bench.py \
-            --rows 100000 --dim 64 --batch-size 25000 --warmups 5 --trials 10 \
-            --baseline artifacts/base-flat.json --max-regression 0.05 \
-            --output artifacts/head-flat.json || status=1
-          head/.venv/bin/python head/benchmarks/upsert_bench.py \
-            --rows 100000 --dim 64 --ingest-batch-size 25000 --trials 5 \
-            --baseline artifacts/base-upsert.json --max-regression 0.10 \
-            --output artifacts/head-upsert.json || status=1
-          exit "$status"
+          head/.venv/bin/python - <<'PY'
+          import json
+          import os
+          import statistics
+          import sys
+          from pathlib import Path
+
+          root = Path("artifacts")
+          rounds = range(1, int(os.environ["BENCH_ROUNDS"]) + 1)
+
+          def load(revision, benchmark, round_number):
+              path = root / f"{revision}-{benchmark}-{round_number}.json"
+              return json.loads(path.read_text())
+
+          def medians(revision, benchmark, value):
+              return [value(load(revision, benchmark, round_number)) for round_number in rounds]
+
+          cases = [
+              {
+                  "name": "Flat search median",
+                  "unit": "ms",
+                  "base_samples": medians("base", "flat", lambda data: data["median_ms"]),
+                  "head_samples": medians("head", "flat", lambda data: data["median_ms"]),
+                  "relative_budget": 0.05,
+                  "absolute_budget": 0.05,
+              },
+              {
+                  "name": "Flat ingest",
+                  "unit": "s",
+                  "base_samples": medians("base", "flat", lambda data: data["ingest_seconds"]),
+                  "head_samples": medians("head", "flat", lambda data: data["ingest_seconds"]),
+                  "relative_budget": 0.05,
+                  "absolute_budget": 0.10,
+              },
+          ]
+          first_upsert = load("base", "upsert", 1)
+          for size in sorted(first_upsert["updates"], key=int):
+              cases.append(
+                  {
+                      "name": f"Upsert {size} row(s)",
+                      "unit": "ms",
+                      "base_samples": medians(
+                          "base", "upsert", lambda data, size=size: data["updates"][size]["median_ms"]
+                      ),
+                      "head_samples": medians(
+                          "head", "upsert", lambda data, size=size: data["updates"][size]["median_ms"]
+                      ),
+                      "relative_budget": 0.10,
+                      "absolute_budget": 1.0,
+                  }
+              )
+
+          warning = False
+          for case in cases:
+              baseline = statistics.median(case["base_samples"])
+              candidate = statistics.median(case["head_samples"])
+              absolute_change = candidate - baseline
+              relative_change = candidate / baseline - 1.0
+              case.update(
+                  {
+                      "baseline": baseline,
+                      "candidate": candidate,
+                      "absolute_change": absolute_change,
+                      "relative_change": relative_change,
+                      "warning": (
+                          relative_change > case["relative_budget"]
+                          and absolute_change > case["absolute_budget"]
+                      ),
+                  }
+              )
+              warning = warning or case["warning"]
+              print(
+                  f"{case['name']}: {relative_change:+.2%}, "
+                  f"{absolute_change:+.3f} {case['unit']}, warning={case['warning']}"
+              )
+
+          comparison = {
+              "schema_version": 1,
+              "rounds": len(list(rounds)),
+              "alternating_order": True,
+              "warning": warning,
+              "cases": cases,
+          }
+          (root / "comparison.json").write_text(
+              json.dumps(comparison, indent=2, sort_keys=True) + "\n"
+          )
+          sys.exit(1 if warning else 0)
+          PY
       - name: Write performance summary
         if: always()
         env:
@@ -77,38 +177,25 @@ jobs:
           from pathlib import Path
 
           root = Path("artifacts")
-          base_flat = json.loads((root / "base-flat.json").read_text())
-          head_flat = json.loads((root / "head-flat.json").read_text())
-          base_upsert = json.loads((root / "base-upsert.json").read_text())
-          head_upsert = json.loads((root / "head-upsert.json").read_text())
-
-          def change(current, baseline):
-              return current / baseline - 1.0
+          comparison = json.loads((root / "comparison.json").read_text())
 
           lines = [
               "## Performance comparison",
               "",
               f"Candidate comparison step: **{os.environ['CANDIDATE_OUTCOME']}**",
+              f"Rounds: **{comparison['rounds']}**, alternating base/head order",
               "",
-              "| Case | Base | Candidate | Change | Warning budget |",
-              "|---|---:|---:|---:|---:|",
-              (
-                  "| Flat search median | "
-                  f"{base_flat['median_ms']:.3f} ms | {head_flat['median_ms']:.3f} ms | "
-                  f"{change(head_flat['median_ms'], base_flat['median_ms']):+.2%} | +5% |"
-              ),
-              (
-                  "| Flat ingest | "
-                  f"{base_flat['ingest_seconds']:.3f} s | {head_flat['ingest_seconds']:.3f} s | "
-                  f"{change(head_flat['ingest_seconds'], base_flat['ingest_seconds']):+.2%} | +5% |"
-              ),
+              "| Case | Base | Candidate | Relative | Absolute | Budgets | Warning |",
+              "|---|---:|---:|---:|---:|---:|:---:|",
           ]
-          for size in sorted(base_upsert["updates"], key=int):
-              before = base_upsert["updates"][size]["median_ms"]
-              after = head_upsert["updates"][size]["median_ms"]
+          for case in comparison["cases"]:
               lines.append(
-                  f"| Upsert {size} row(s) | {before:.3f} ms | {after:.3f} ms | "
-                  f"{change(after, before):+.2%} | +10% |"
+                  f"| {case['name']} | {case['baseline']:.3f} {case['unit']} | "
+                  f"{case['candidate']:.3f} {case['unit']} | "
+                  f"{case['relative_change']:+.2%} | "
+                  f"{case['absolute_change']:+.3f} {case['unit']} | "
+                  f"{case['relative_budget']:.0%} and {case['absolute_budget']:.2f} "
+                  f"{case['unit']} | {'yes' if case['warning'] else 'no'} |"
               )
           with open(os.environ["GITHUB_STEP_SUMMARY"], "a", encoding="utf-8") as summary:
               summary.write("\n".join(lines) + "\n")

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -1,0 +1,49 @@
+name: Pull Request CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pr-ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  rust:
+    name: Rust checks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+      - name: Check formatting
+        run: cargo fmt --all -- --check
+      - name: Run Rust tests
+        run: cargo test --locked
+
+  python:
+    name: Python API checks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+      - name: Install package and test dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install pytest
+          python -m pip install --config-settings=maturin.build-args=--locked .
+      - name: Run Python API tests
+        run: python -m pytest tests/standard_tests tests/test_explicit_api_parameters.py -q

--- a/benchmarks/upsert_bench.py
+++ b/benchmarks/upsert_bench.py
@@ -26,6 +26,11 @@ def parse_args():
     parser.add_argument("--update-sizes", default="1,100")
     parser.add_argument("--trials", type=int, default=5)
     parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument(
+        "--index-mode",
+        default=None,
+        help="Optional index mode to build before measuring updates.",
+    )
     parser.add_argument("--output", type=Path)
     parser.add_argument("--baseline", type=Path)
     parser.add_argument("--max-regression", type=float, default=0.10)
@@ -66,6 +71,8 @@ def bench(args):
         vectors = rng.random((end - start, args.dim), dtype=np.float32)
         collection.add_items(vectors, list(range(start, end)))
     collection.commit()
+    if args.index_mode:
+        collection.build_index(args.index_mode, None)
 
     updates = {}
     for update_size in update_sizes:
@@ -87,28 +94,33 @@ def bench(args):
         "dimension": args.dim,
         "trials": args.trials,
         "seed": args.seed,
+        "index_mode": args.index_mode.upper() if args.index_mode else None,
         "rayon_threads": os.environ.get("RAYON_NUM_THREADS", "default"),
         "platform": platform.platform(),
         "python": platform.python_version(),
         "updates": updates,
     }
-    print(json.dumps(result, indent=2, sort_keys=True))
-
-    if args.output:
-        args.output.parent.mkdir(parents=True, exist_ok=True)
-        args.output.write_text(json.dumps(result, indent=2, sort_keys=True) + "\n")
 
     exit_code = 0
     if args.baseline:
         baseline = json.loads(args.baseline.read_text())
+        regressions = {}
         for update_size, current in updates.items():
             previous = baseline["updates"].get(update_size)
             if previous is None:
                 continue
             change = current["median_ms"] / previous["median_ms"] - 1.0
+            regressions[update_size] = change
             print(f"Update size {update_size} median change: {change:+.2%}")
             if change > args.max_regression:
                 exit_code = 1
+        result["median_regressions"] = regressions
+
+    print(json.dumps(result, indent=2, sort_keys=True))
+
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(json.dumps(result, indent=2, sort_keys=True) + "\n")
 
     if not args.keep_data:
         shutil.rmtree(test_dir, ignore_errors=True)

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1646,10 +1646,7 @@ impl Collection {
         let field_db_path = collection_path.join("fields_db");
         let stable_field_ids_path = collection_path.join(STABLE_FIELD_IDS_FILE);
         if mode == OpenMode::ReadWrite && is_new_collection {
-            Self::atomic_write_file(
-                &stable_field_ids_path,
-                b"stable-internal-id-v1\n",
-            )?;
+            Self::atomic_write_file(&stable_field_ids_path, b"stable-internal-id-v1\n")?;
         }
         if !stable_field_ids_path.exists() {
             return Err(LynseError::Storage(
@@ -1732,10 +1729,7 @@ impl Collection {
 
             let external_map_repaired = coll.repair_external_id_map_for_open()?;
 
-            if recovered_vector_updates
-                || id_map_repaired
-                || recovered_wal
-                || external_map_repaired
+            if recovered_vector_updates || id_map_repaired || recovered_wal || external_map_repaired
             {
                 if let Some(mode) = coll.index_mode.clone() {
                     coll.build_index(&mode)?;
@@ -2404,7 +2398,8 @@ impl Collection {
                     existing_vector_rows.push(row as u64);
                     existing_encoded_vectors
                         .extend_from_slice(&seg.encoded_data[encoded_start..encoded_end]);
-                    existing_decoded_vectors.extend_from_slice(&seg.data[decoded_start..decoded_end]);
+                    existing_decoded_vectors
+                        .extend_from_slice(&seg.data[decoded_start..decoded_end]);
                     if let Some(field) = seg.fields.get(i) {
                         existing_field_user_ids.push(user_id);
                         existing_field_values.push(field.clone());
@@ -2452,10 +2447,8 @@ impl Collection {
                 let encoded_vectors = if seg.dtype == self.vector_dtype {
                     existing_encoded_vectors.as_slice()
                 } else {
-                    encoded = encode_f32_slice_as_le_bytes(
-                        &existing_decoded_vectors,
-                        self.vector_dtype,
-                    );
+                    encoded =
+                        encode_f32_slice_as_le_bytes(&existing_decoded_vectors, self.vector_dtype);
                     encoded.as_slice()
                 };
                 self.vector_store.overwrite_encoded_rows(
@@ -2649,15 +2642,16 @@ impl Collection {
         Ok(())
     }
 
-    fn append_external_id_map_delta(&self, entries: Vec<ExternalIdEntry>) -> Result<()> {
+    fn append_external_id_map_delta(&self, entries: &[ExternalIdEntry]) -> Result<Option<u64>> {
         let entries: Vec<ExternalIdEntry> = entries
-            .into_iter()
+            .iter()
             .filter(|entry| {
-                !matches!(entry.external_id, ExternalId::Int(value) if value == entry.internal_id)
+                !matches!(&entry.external_id, ExternalId::Int(value) if *value == entry.internal_id)
             })
+            .cloned()
             .collect();
         if entries.is_empty() {
-            return Ok(());
+            return Ok(None);
         }
         let file = ExternalIdMapFile {
             version: EXTERNAL_ID_MAP_VERSION,
@@ -2667,14 +2661,55 @@ impl Collection {
         let bytes = Self::serialize_external_id_map_binary(&file)?;
         let len = bytes.len() as u64;
         use std::io::Write;
+        let path = Self::external_id_map_delta_bin_path(&self.path);
+        let previous_len = match std::fs::metadata(&path) {
+            Ok(metadata) => metadata.len(),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => 0,
+            Err(error) => return Err(error.into()),
+        };
         let mut f = std::fs::OpenOptions::new()
             .create(true)
             .append(true)
-            .open(Self::external_id_map_delta_bin_path(&self.path))?;
-        f.write_all(&len.to_le_bytes())?;
-        f.write_all(&bytes)?;
-        f.flush()?;
+            .open(&path)?;
+        let append_result = (|| -> std::io::Result<()> {
+            f.write_all(&len.to_le_bytes())?;
+            f.write_all(&bytes)?;
+            f.flush()
+        })();
+        if let Err(append_error) = append_result {
+            let rollback_result = f.set_len(previous_len).and_then(|_| f.flush());
+            return match rollback_result {
+                Ok(()) => Err(append_error.into()),
+                Err(rollback_error) => Err(LynseError::Storage(format!(
+                    "external ID delta append failed: {append_error}; rollback failed: {rollback_error}"
+                ))),
+            };
+        }
+        Ok(Some(previous_len))
+    }
+
+    fn truncate_external_id_map_delta(&self, previous_len: Option<u64>) -> Result<()> {
+        let Some(previous_len) = previous_len else {
+            return Ok(());
+        };
+        use std::io::Write;
+        let path = Self::external_id_map_delta_bin_path(&self.path);
+        let mut file = std::fs::OpenOptions::new().write(true).open(&path)?;
+        file.set_len(previous_len)?;
+        file.flush()?;
         Ok(())
+    }
+
+    fn rollback_external_id_batch(
+        &mut self,
+        previous_next_internal_id: u64,
+        entries: &[ExternalIdEntry],
+    ) {
+        self.next_internal_id = previous_next_internal_id;
+        for entry in entries {
+            self.external_to_internal_id.remove(&entry.external_id);
+            self.internal_to_external_id.remove(&entry.internal_id);
+        }
     }
 
     fn load_external_id_map_file(path: &Path) -> Result<Option<ExternalIdMapFile>> {
@@ -3799,8 +3834,6 @@ impl Collection {
         self.validate_new_external_ids(external_ids)?;
         let prev_next_internal_id = self.next_internal_id;
         let internal_ids = self.allocate_internal_ids(n_vectors)?;
-        let prev_external_to_internal = self.external_to_internal_id.clone();
-        let prev_internal_to_external = self.internal_to_external_id.clone();
 
         let delta_entries: Vec<ExternalIdEntry> = external_ids
             .iter()
@@ -3819,7 +3852,13 @@ impl Collection {
                 .insert(entry.internal_id, entry.external_id.clone());
         }
 
-        self.append_external_id_map_delta(delta_entries)?;
+        let delta_previous_len = match self.append_external_id_map_delta(&delta_entries) {
+            Ok(previous_len) => previous_len,
+            Err(err) => {
+                self.rollback_external_id_batch(prev_next_internal_id, &delta_entries);
+                return Err(err);
+            }
+        };
 
         let encoded_vectors = encode_f32_slice_as_le_bytes(vectors, self.vector_dtype);
         let result = self.buffer_add_items_encoded(
@@ -3832,10 +3871,12 @@ impl Collection {
         );
 
         if let Err(err) = result {
-            self.next_internal_id = prev_next_internal_id;
-            self.external_to_internal_id = prev_external_to_internal;
-            self.internal_to_external_id = prev_internal_to_external;
-            let _ = self.write_external_id_map();
+            self.rollback_external_id_batch(prev_next_internal_id, &delta_entries);
+            if let Err(rollback_error) = self.truncate_external_id_map_delta(delta_previous_len) {
+                return Err(LynseError::Storage(format!(
+                    "record buffering failed: {err}; external ID delta rollback failed: {rollback_error}"
+                )));
+            }
             return Err(err);
         }
 
@@ -4566,36 +4607,14 @@ impl Collection {
             // candidate generators, so filtered queries use the exact filtered
             // mmap path for correctness.
             self.brute_force_search_filtered(query, search_k, &search_params)?
-        } else if let Some(ref pq) = self.pq_index {
-            // PQ (Product Quantization) two-pass search
-            let metric = collection_metric;
-            let all_data = self.vector_store.read_all_f32()?;
-            let (indices, dists) = pq.search(query, search_k, &all_data, metric, PQ_OVERSAMPLE);
-            (indices.into_iter().map(|i| i as u64).collect(), dists)
-        } else if let Some(ref rq) = self.rabitq_index {
-            // RaBitQ binary two-pass search
-            let metric = collection_metric;
-            let all_data = self.vector_store.read_all_f32()?;
-            let (indices, dists) = rq.search(query, search_k, &all_data, metric, RABITQ_OVERSAMPLE);
-            (indices.into_iter().map(|i| i as u64).collect(), dists)
-        } else if let Some(ref pv) = self.polarvec_index {
-            // PolarVec multi-bit LUT two-pass search
-            let metric = collection_metric;
-            let all_data = self.vector_store.read_all_f32()?;
-            let (indices, dists) =
-                pv.search(query, search_k, &all_data, metric, POLARVEC_OVERSAMPLE);
-            (indices.into_iter().map(|i| i as u64).collect(), dists)
+        } else if self.has_auxiliary_quantized_index() {
+            self.search_auxiliary_quantized(query, search_k, collection_metric)?
         } else {
             // Unfiltered: zero-copy mmap + fused parallel topk (~5ms for 1M×128)
             let metric = collection_metric;
             approx_applied_eps = approx_cfg.map(|config| config.eps);
-            self.vector_store.search(
-                query,
-                search_k,
-                metric,
-                self.resolve_use_sq8(),
-                approx_cfg,
-            )?
+            self.vector_store
+                .search(query, search_k, metric, self.resolve_use_sq8(), approx_cfg)?
         };
 
         let (pending_ids, pending_dists) = self.pending_search(
@@ -4623,10 +4642,7 @@ impl Collection {
         let (result_ids, mut result_dists) =
             self.filter_tombstoned_limit(result_ids, result_dists, k);
         if let Some(approx_eps) = approx_applied_eps {
-            crate::storage::approx_search::round_distances_to_eps(
-                &mut result_dists,
-                approx_eps,
-            );
+            crate::storage::approx_search::round_distances_to_eps(&mut result_dists, approx_eps);
         }
 
         Ok(SearchResult {
@@ -5257,45 +5273,8 @@ impl Collection {
 
                 let (result_ids, result_dists) = if let Some(ref idx) = self.index {
                     idx.search(query, search_k, &search_params)?
-                } else if let Some(ref pq) = self.pq_index {
-                    let metric = self.resolve_metric();
-                    let guard = self.vector_store.read_mmap()?;
-                    match guard.as_ref() {
-                        None => (vec![], vec![]),
-                        Some(fm) => {
-                            let all_data = fm.as_f32_cow();
-                            let (indices, dists) =
-                                pq.search(query, search_k, &all_data, metric, PQ_OVERSAMPLE);
-                            let ids: Vec<u64> = indices.iter().map(|&i| i as u64).collect();
-                            (ids, dists)
-                        }
-                    }
-                } else if let Some(ref rq) = self.rabitq_index {
-                    let metric = self.resolve_metric();
-                    let guard = self.vector_store.read_mmap()?;
-                    match guard.as_ref() {
-                        None => (vec![], vec![]),
-                        Some(fm) => {
-                            let all_data = fm.as_f32_cow();
-                            let (indices, dists) =
-                                rq.search(query, search_k, &all_data, metric, RABITQ_OVERSAMPLE);
-                            let ids: Vec<u64> = indices.iter().map(|&i| i as u64).collect();
-                            (ids, dists)
-                        }
-                    }
-                } else if let Some(ref pv) = self.polarvec_index {
-                    let metric = self.resolve_metric();
-                    let guard = self.vector_store.read_mmap()?;
-                    match guard.as_ref() {
-                        None => (vec![], vec![]),
-                        Some(fm) => {
-                            let all_data = fm.as_f32_cow();
-                            let (indices, dists) =
-                                pv.search(query, search_k, &all_data, metric, POLARVEC_OVERSAMPLE);
-                            let ids: Vec<u64> = indices.iter().map(|&i| i as u64).collect();
-                            (ids, dists)
-                        }
-                    }
+                } else if self.has_auxiliary_quantized_index() {
+                    self.search_auxiliary_quantized(query, search_k, self.resolve_metric())?
                 } else if search_params.subset_indices.is_some() {
                     self.brute_force_search_filtered(query, search_k, &search_params)?
                 } else {
@@ -5330,6 +5309,34 @@ impl Collection {
         results.into_iter().collect()
     }
 
+    fn has_auxiliary_quantized_index(&self) -> bool {
+        self.pq_index.is_some() || self.rabitq_index.is_some() || self.polarvec_index.is_some()
+    }
+
+    fn search_auxiliary_quantized(
+        &self,
+        query: &[f32],
+        k: usize,
+        metric: DistanceMetric,
+    ) -> Result<(Vec<u64>, Vec<f32>)> {
+        let candidates = if let Some(ref pq) = self.pq_index {
+            pq.search_candidates(query, k, metric, PQ_OVERSAMPLE)
+        } else if let Some(ref rq) = self.rabitq_index {
+            rq.search_candidates(query, k, metric, RABITQ_OVERSAMPLE)
+        } else if let Some(ref pv) = self.polarvec_index {
+            pv.search_candidates(query, k, metric, POLARVEC_OVERSAMPLE)
+        } else {
+            return Ok((Vec::new(), Vec::new()));
+        };
+        let (indices, distances) =
+            self.vector_store
+                .rescore_exact_candidates(&candidates, query, k, metric)?;
+        Ok((
+            indices.into_iter().map(|index| index as u64).collect(),
+            distances,
+        ))
+    }
+
     /// Resolve the distance metric from the index_mode string.
     fn resolve_metric(&self) -> DistanceMetric {
         self.index_mode
@@ -5355,13 +5362,9 @@ impl Collection {
             Some(s) => s.as_slice(),
             None => {
                 // No filter — use unfiltered path
-                return self.vector_store.search(
-                    query,
-                    k,
-                    metric,
-                    self.resolve_use_sq8(),
-                    None,
-                );
+                return self
+                    .vector_store
+                    .search(query, k, metric, self.resolve_use_sq8(), None);
             }
         };
 
@@ -5683,7 +5686,7 @@ impl Collection {
         Ok(results)
     }
 
-    fn update_existing_items_in_place(
+    fn apply_existing_items_in_place(
         &mut self,
         ids: &[u64],
         vectors: &[f32],
@@ -5706,8 +5709,7 @@ impl Collection {
             .apply_journaled_encoded_rows(&rows, &encoded, self.vector_dtype)?;
 
         if let Some(field_values) = fields {
-            self.field_store
-                .replace_fields_at_ids(ids, field_values)?;
+            self.field_store.replace_fields_at_ids(ids, field_values)?;
             self.text_index.upsert_documents(ids, field_values, true)?;
         }
 
@@ -5722,11 +5724,18 @@ impl Collection {
             Self::save_tombstone_to_disk(&path, &tombstone)?;
         }
 
-        if let Some(mode) = self.index_mode.clone() {
-            self.build_index(&mode)?;
-        }
-        self.vector_store.finish_pending_updates()?;
         Ok(())
+    }
+
+    fn vector_mutation_requires_index_rebuild(&self) -> bool {
+        let Some(mode) = self.index_mode.as_deref() else {
+            return false;
+        };
+        let upper = mode.to_uppercase();
+        upper.contains("PQ")
+            || upper.contains("RABITQ")
+            || upper.contains("POLARVEC")
+            || Self::resolve_metric_from_type(mode).is_none()
     }
 
     /// Upsert vectors by user ID.
@@ -5767,81 +5776,60 @@ impl Collection {
         }
         Self::validate_unique_ids(ids)?;
 
-        // Existing-only updates do not change row order or the stable ID map.
-        // Use a journaled positional write instead of rebuilding every segment.
-        if ids
-            .iter()
-            .all(|user_id| self.reverse_id_map.contains_key(user_id))
-        {
-            return self.update_existing_items_in_place(ids, vectors, fields);
-        }
+        let mut existing_ids = Vec::new();
+        let mut existing_vectors = Vec::new();
+        let mut existing_fields = fields.map(|_| Vec::new());
+        let mut new_ids = Vec::new();
+        let mut new_vectors = Vec::new();
+        let mut new_fields = fields.map(|_| Vec::new());
 
-        let (mut all_vectors, n_total) = {
-            let guard = self.vector_store.read_mmap()?;
-            match guard.as_ref() {
-                None => (Vec::new(), 0usize),
-                Some(fm) => (fm.as_f32_cow().into_owned(), fm.len()),
-            }
-        };
-        if all_vectors.len() != n_total * dim {
-            return Err(LynseError::Storage(
-                "vector store length does not match collection dimension".to_string(),
-            ));
-        }
-
-        let mut new_id_map = self.id_map.clone();
-        let mut new_reverse_id_map = self.reverse_id_map.clone();
-        let mut field_rows = Vec::new();
-        let mut field_values = Vec::new();
-        let mut tombstone_changed = false;
-
-        {
-            let mut tombstone = self.tombstone.write();
-            for (i, &user_id) in ids.iter().enumerate() {
-                let src_start = i * dim;
-                let src_end = src_start + dim;
-                if let Some(row) = new_reverse_id_map.get(&user_id).copied() {
-                    let dst_start = row * dim;
-                    let dst_end = dst_start + dim;
-                    all_vectors[dst_start..dst_end].copy_from_slice(&vectors[src_start..src_end]);
-                    if tombstone.remove(&user_id) {
-                        tombstone_changed = true;
-                    }
-                } else {
-                    let row = new_id_map.len();
-                    all_vectors.extend_from_slice(&vectors[src_start..src_end]);
-                    new_id_map.push(user_id);
-                    new_reverse_id_map.insert(user_id, row);
+        for (index, &user_id) in ids.iter().enumerate() {
+            let vector = &vectors[index * dim..(index + 1) * dim];
+            if self.reverse_id_map.contains_key(&user_id) {
+                existing_ids.push(user_id);
+                existing_vectors.extend_from_slice(vector);
+                if let (Some(source), Some(destination)) = (fields, existing_fields.as_mut()) {
+                    destination.push(source[index].clone());
                 }
-
-                if let Some(field_list) = fields {
-                    field_rows.push(user_id);
-                    field_values.push(field_list[i].clone());
+            } else {
+                new_ids.push(user_id);
+                new_vectors.extend_from_slice(vector);
+                if let (Some(source), Some(destination)) = (fields, new_fields.as_mut()) {
+                    destination.push(source[index].clone());
                 }
             }
         }
 
-        self.vector_store
-            .replace_data_with_id_map(&all_vectors, &new_id_map)?;
-        self.id_map = new_id_map;
-        self.reverse_id_map = new_reverse_id_map;
-
-        if fields.is_some() {
-            self.field_store
-                .replace_fields_at_ids(&field_rows, &field_values)?;
-            self.text_index
-                .upsert_documents(ids, fields.unwrap(), true)?;
-        }
-        if tombstone_changed {
-            let path = self.path.join("tombstone.bin");
-            let set = self.tombstone.read();
-            Self::save_tombstone_to_disk(&path, &set)?;
+        let rebuild_index = self.vector_mutation_requires_index_rebuild();
+        if rebuild_index {
+            // From this point on, any partial write makes the old index stale.
+            // Drop it before mutation so an error falls back to exact search.
+            self.index = None;
+            self.pq_index = None;
+            self.rabitq_index = None;
+            self.polarvec_index = None;
         }
 
-        if let Some(mode) = self.index_mode.clone() {
+        if !existing_ids.is_empty() {
+            self.apply_existing_items_in_place(
+                &existing_ids,
+                &existing_vectors,
+                existing_fields.as_deref(),
+            )?;
+        }
+
+        if !new_ids.is_empty() {
+            self.add_items(&new_vectors, new_ids.len(), &new_ids, new_fields.as_deref())?;
+        }
+
+        self.flush_pending_ingest()?;
+        if rebuild_index {
+            let mode = self.index_mode.clone().ok_or_else(|| {
+                LynseError::Storage("index mode disappeared during upsert".to_string())
+            })?;
             self.build_index(&mode)?;
         }
-
+        self.vector_store.finish_pending_updates()?;
         Ok(())
     }
 
@@ -6267,7 +6255,8 @@ impl Collection {
                 let external_id = ExternalId::Int(internal_id);
                 self.internal_to_external_id
                     .insert(internal_id, external_id.clone());
-                self.external_to_internal_id.insert(external_id, internal_id);
+                self.external_to_internal_id
+                    .insert(external_id, internal_id);
             }
         }
         self.write_external_id_map()?;
@@ -6513,9 +6502,7 @@ impl Collection {
             ids.push(record.id);
             external_entries.push((
                 record.id,
-                record
-                    .external_id
-                    .unwrap_or(ExternalId::Int(record.id)),
+                record.external_id.unwrap_or(ExternalId::Int(record.id)),
             ));
             fields.push(record.field);
             row_count += 1;
@@ -6556,8 +6543,12 @@ impl Collection {
                     internal_id
                 )));
             }
-            if internal_to_external.insert(internal_id, external_id.clone()).is_some()
-                || external_to_internal.insert(external_id, internal_id).is_some()
+            if internal_to_external
+                .insert(internal_id, external_id.clone())
+                .is_some()
+                || external_to_internal
+                    .insert(external_id, internal_id)
+                    .is_some()
             {
                 return Err(LynseError::InvalidArgument(
                     "export metadata contains duplicate external IDs".to_string(),
@@ -7494,7 +7485,10 @@ mod tests {
 
         let error = coll.read_vectors_by_ids_only(&[0]).unwrap_err();
         assert!(error.to_string().contains("vector id 0 does not exist"));
-        assert_eq!(coll.read_vectors_by_ids_only(&[10]).unwrap(), vec![1.0, 2.0]);
+        assert_eq!(
+            coll.read_vectors_by_ids_only(&[10]).unwrap(),
+            vec![1.0, 2.0]
+        );
     }
 
     #[test]
@@ -7530,6 +7524,103 @@ mod tests {
             coll.external_ids_for_internal_ids(&result.ids),
             vec![ExternalId::String("doc-a".into()), ExternalId::Int(42)]
         );
+    }
+
+    #[test]
+    fn external_id_delta_failure_rolls_back_allocator_and_mappings() {
+        let tmp = TempDir::new().unwrap();
+        let mut coll = Collection::open(tmp.path(), "col", 3, 100).unwrap();
+        let first_id = ExternalId::String("existing".into());
+        coll.add_records(&[1.0, 0.0, 0.0], 1, std::slice::from_ref(&first_id), None)
+            .unwrap();
+        coll.checkpoint().unwrap();
+
+        let delta_path = coll.path.join(EXTERNAL_ID_MAP_DELTA_BIN_FILE);
+        std::fs::create_dir(&delta_path).unwrap();
+        let failed_id = ExternalId::String("retry-me".into());
+        let err = coll
+            .add_records(&[0.0, 1.0, 0.0], 1, std::slice::from_ref(&failed_id), None)
+            .unwrap_err();
+        assert!(matches!(err, LynseError::Io(_)));
+        assert_eq!(coll.next_internal_id, 1);
+        assert!(coll.is_external_id_exists(&first_id));
+        assert!(!coll.is_external_id_exists(&failed_id));
+        assert_eq!(
+            coll.external_ids_for_internal_ids(&[0]),
+            vec![first_id.clone()]
+        );
+
+        std::fs::remove_dir(&delta_path).unwrap();
+        let retried = coll
+            .add_records(&[0.0, 1.0, 0.0], 1, &[failed_id.clone()], None)
+            .unwrap();
+        assert_eq!(retried, vec![1]);
+        assert_eq!(
+            coll.internal_ids_for_external_ids(&[failed_id]).unwrap(),
+            vec![1]
+        );
+    }
+
+    #[test]
+    fn external_id_batch_rollback_removes_only_the_failed_batch() {
+        let tmp = TempDir::new().unwrap();
+        let mut coll = Collection::open(tmp.path(), "col", 2, 100).unwrap();
+        let existing = ExternalId::String("existing".into());
+        coll.add_records(&[1.0, 0.0], 1, std::slice::from_ref(&existing), None)
+            .unwrap();
+
+        let failed = ExternalIdEntry {
+            internal_id: 1,
+            external_id: ExternalId::String("failed".into()),
+        };
+        coll.next_internal_id = 2;
+        coll.external_to_internal_id
+            .insert(failed.external_id.clone(), failed.internal_id);
+        coll.internal_to_external_id
+            .insert(failed.internal_id, failed.external_id.clone());
+
+        coll.rollback_external_id_batch(1, std::slice::from_ref(&failed));
+
+        assert_eq!(coll.next_internal_id, 1);
+        assert!(coll.is_external_id_exists(&existing));
+        assert!(!coll.is_external_id_exists(&failed.external_id));
+        assert_eq!(coll.external_ids_for_internal_ids(&[0]), vec![existing]);
+    }
+
+    #[test]
+    fn external_id_delta_truncate_restores_reopen_state() {
+        let tmp = TempDir::new().unwrap();
+        {
+            let mut coll = Collection::open(tmp.path(), "col", 2, 100).unwrap();
+            let existing = ExternalId::String("existing".into());
+            coll.add_records(&[1.0, 0.0], 1, std::slice::from_ref(&existing), None)
+                .unwrap();
+            coll.checkpoint().unwrap();
+
+            let failed = ExternalIdEntry {
+                internal_id: 1,
+                external_id: ExternalId::String("failed".into()),
+            };
+            coll.next_internal_id = 2;
+            coll.external_to_internal_id
+                .insert(failed.external_id.clone(), failed.internal_id);
+            coll.internal_to_external_id
+                .insert(failed.internal_id, failed.external_id.clone());
+            let previous_len = coll
+                .append_external_id_map_delta(std::slice::from_ref(&failed))
+                .unwrap();
+
+            coll.rollback_external_id_batch(1, std::slice::from_ref(&failed));
+            coll.truncate_external_id_map_delta(previous_len).unwrap();
+        }
+
+        let mut coll = Collection::open(tmp.path(), "col", 2, 100).unwrap();
+        assert!(coll.is_external_id_exists(&ExternalId::String("existing".into())));
+        assert!(!coll.is_external_id_exists(&ExternalId::String("failed".into())));
+        let retried = coll
+            .add_records(&[0.0, 1.0], 1, &[ExternalId::String("failed".into())], None)
+            .unwrap();
+        assert_eq!(retried, vec![1]);
     }
 
     #[test]
@@ -7673,6 +7764,67 @@ mod tests {
         assert_eq!(results.len(), 2);
         assert_eq!(results[0].ids, vec![10, 12]);
         assert_eq!(results[1].ids, vec![11, 12]);
+    }
+
+    #[test]
+    fn quantized_single_and_batch_search_rescore_segment_mmaps() {
+        for dtype in [VectorDtype::F32, VectorDtype::F16] {
+            let tmp = TempDir::new().unwrap();
+            let mut coll = Collection::open_with_dtype(tmp.path(), "col", 16, 100, dtype).unwrap();
+            let mut vectors = vec![0.0f32; 300 * 16];
+            for row in 0..300 {
+                for dim in 0..16 {
+                    vectors[row * 16 + dim] = row as f32 * 0.0001 + dim as f32 * 0.00001;
+                }
+            }
+            vectors[..16].fill(0.0);
+            vectors[0] = 1.0;
+            vectors[16..32].fill(0.0);
+            vectors[17] = 1.0;
+            let ids: Vec<u64> = (1000..1300).collect();
+            for start in (0..300).step_by(100) {
+                coll.add_items(
+                    &vectors[start * 16..(start + 100) * 16],
+                    100,
+                    &ids[start..start + 100],
+                    None,
+                )
+                .unwrap();
+                coll.flush_pending_ingest().unwrap();
+            }
+            assert!(
+                coll.vector_store.segment_paths().len() > 1,
+                "test setup must span multiple segments"
+            );
+
+            let queries = [
+                1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+                0.0, //
+                0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+            ];
+
+            for mode in ["FLAT-IP-PQ", "FLAT-IP-RABITQ", "FLAT-IP-POLARVEC"] {
+                coll.build_index(mode).unwrap();
+                let singles = [
+                    coll.search(&queries[..16], 1, None, 10, false, 1e-4)
+                        .unwrap(),
+                    coll.search(&queries[16..], 1, None, 10, false, 1e-4)
+                        .unwrap(),
+                ];
+                let batch = coll.batch_search(&queries, 2, 1, None, 10).unwrap();
+
+                assert_eq!(singles[0].ids, vec![1000], "{dtype:?} {mode}");
+                assert_eq!(singles[1].ids, vec![1001], "{dtype:?} {mode}");
+                for (single, batched) in singles.iter().zip(batch.iter()) {
+                    assert_eq!(single.ids, batched.ids, "{dtype:?} {mode}");
+                    assert_eq!(single.distances, batched.distances, "{dtype:?} {mode}");
+                }
+                assert!(
+                    !coll.path.join("vectors.compat.bin").exists(),
+                    "{dtype:?} {mode} created a compatibility mmap"
+                );
+            }
+        }
     }
 
     #[test]
@@ -8403,10 +8555,7 @@ mod tests {
             coll.add_items(&[1.0, 0.0, 0.0, 0.0], 1, &[7], None)
                 .unwrap();
             coll.commit().unwrap();
-            let replacement = encode_f32_slice_as_le_bytes(
-                &[0.0, 1.0, 0.0, 0.0],
-                VectorDtype::F32,
-            );
+            let replacement = encode_f32_slice_as_le_bytes(&[0.0, 1.0, 0.0, 0.0], VectorDtype::F32);
             coll.vector_store
                 .write_update_journal(&[0], &replacement)
                 .unwrap();
@@ -8416,7 +8565,9 @@ mod tests {
             Ok(_) => panic!("read-only open should reject a pending positional update"),
             Err(error) => error,
         };
-        assert!(read_only_error.to_string().contains("pending vector updates"));
+        assert!(read_only_error
+            .to_string()
+            .contains("pending vector updates"));
 
         let coll = Collection::open(tmp.path(), "col", 4, 100).unwrap();
         let (vectors, _) = coll.read_vectors_by_ids(&[7]).unwrap();
@@ -8466,6 +8617,119 @@ mod tests {
         assert_eq!(fields[1].get("tag"), Some(&serde_json::json!("inserted")));
         assert!(coll.query_fields("\"tag\" = 'old'").unwrap().is_empty());
         assert_eq!(coll.query_fields("\"tag\" = 'new'").unwrap(), vec![1]);
+    }
+
+    #[test]
+    fn mixed_flat_upsert_preserves_rows_and_vector_generation() {
+        let tmp = TempDir::new().unwrap();
+        let mut coll = Collection::open(tmp.path(), "col", 4, 100).unwrap();
+        let initial_fields = vec![
+            HashMap::from([("tag".to_string(), serde_json::json!("ten"))]),
+            HashMap::from([("tag".to_string(), serde_json::json!("twenty"))]),
+            HashMap::from([("tag".to_string(), serde_json::json!("thirty"))]),
+        ];
+        coll.add_items(
+            &[
+                1.0, 0.0, 0.0, 0.0, //
+                0.0, 1.0, 0.0, 0.0, //
+                0.0, 0.0, 1.0, 0.0,
+            ],
+            3,
+            &[10, 20, 30],
+            Some(&initial_fields),
+        )
+        .unwrap();
+        coll.commit().unwrap();
+        coll.build_index("FLAT-IP").unwrap();
+        let segments_before = coll.vector_store.segment_paths();
+
+        let fields = vec![
+            HashMap::from([("tag".to_string(), serde_json::json!("twenty-updated"))]),
+            HashMap::from([("tag".to_string(), serde_json::json!("forty"))]),
+            HashMap::from([("tag".to_string(), serde_json::json!("ten-updated"))]),
+            HashMap::from([("tag".to_string(), serde_json::json!("fifty"))]),
+        ];
+        coll.upsert_items(
+            &[20, 40, 10, 50],
+            &[
+                0.0, 2.0, 0.0, 0.0, //
+                0.0, 0.0, 2.0, 0.0, //
+                2.0, 0.0, 0.0, 0.0, //
+                0.0, 0.0, 0.0, 2.0,
+            ],
+            4,
+            Some(&fields),
+        )
+        .unwrap();
+
+        let segments_after = coll.vector_store.segment_paths();
+        assert!(
+            segments_before
+                .iter()
+                .all(|segment| segments_after.contains(segment)),
+            "mixed flat upsert replaced the existing vector generation"
+        );
+        assert_eq!(coll.id_map, vec![10, 20, 30, 40, 50]);
+        let (vectors, fields) = coll.read_vectors_by_ids(&[10, 20, 30, 40, 50]).unwrap();
+        assert_eq!(
+            vectors,
+            vec![
+                2.0, 0.0, 0.0, 0.0, //
+                0.0, 2.0, 0.0, 0.0, //
+                0.0, 0.0, 1.0, 0.0, //
+                0.0, 0.0, 2.0, 0.0, //
+                0.0, 0.0, 0.0, 2.0,
+            ]
+        );
+        assert_eq!(
+            fields[0].get("tag"),
+            Some(&serde_json::json!("ten-updated"))
+        );
+        assert_eq!(
+            fields[1].get("tag"),
+            Some(&serde_json::json!("twenty-updated"))
+        );
+        assert_eq!(fields[2].get("tag"), Some(&serde_json::json!("thirty")));
+        assert_eq!(fields[3].get("tag"), Some(&serde_json::json!("forty")));
+        assert_eq!(fields[4].get("tag"), Some(&serde_json::json!("fifty")));
+    }
+
+    #[test]
+    fn mixed_upsert_rebuilds_ann_index_once_with_updated_rows() {
+        let tmp = TempDir::new().unwrap();
+        let mut coll = Collection::open(tmp.path(), "col", 4, 100).unwrap();
+        coll.add_items(
+            &[
+                1.0, 0.0, 0.0, 0.0, //
+                0.0, 0.0, 0.0, 1.0, //
+                0.0, -1.0, 0.0, 0.0,
+            ],
+            3,
+            &[1, 2, 4],
+            None,
+        )
+        .unwrap();
+        coll.build_index("HNSW-IP").unwrap();
+
+        coll.upsert_items(
+            &[1, 3],
+            &[
+                0.0, 1.0, 0.0, 0.0, //
+                0.0, 0.0, 1.0, 0.0,
+            ],
+            2,
+            None,
+        )
+        .unwrap();
+
+        let updated = coll
+            .search(&[0.0, 1.0, 0.0, 0.0], 1, None, 10, false, 1e-4)
+            .unwrap();
+        let inserted = coll
+            .search(&[0.0, 0.0, 1.0, 0.0], 1, None, 10, false, 1e-4)
+            .unwrap();
+        assert_eq!(updated.ids, vec![1]);
+        assert_eq!(inserted.ids, vec![3]);
     }
 
     #[test]

--- a/src/python/mod.rs
+++ b/src/python/mod.rs
@@ -144,7 +144,10 @@ impl PyRemoteHttpClient {
                 ("collection_name", collection_name.to_string()),
                 ("dim", dim.to_string()),
                 ("n_vectors", n_vectors.to_string()),
-                ("vector_encoding", normalize_remote_vector_encoding(vector_encoding)?),
+                (
+                    "vector_encoding",
+                    normalize_remote_vector_encoding(vector_encoding)?,
+                ),
                 ("return_ids", return_ids.to_string()),
             ],
         );
@@ -2510,13 +2513,9 @@ fn percent_encode(value: &str) -> String {
     let mut out = String::with_capacity(value.len());
     for byte in value.bytes() {
         match byte {
-            b'A'..=b'Z'
-            | b'a'..=b'z'
-            | b'0'..=b'9'
-            | b'-'
-            | b'_'
-            | b'.'
-            | b'~' => out.push(byte as char),
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
+                out.push(byte as char)
+            }
             _ => {
                 out.push('%');
                 out.push_str(&format!("{:02X}", byte));
@@ -2526,9 +2525,7 @@ fn percent_encode(value: &str) -> String {
     out
 }
 
-fn query_params_from_pydict(
-    params: Option<&Bound<'_, PyDict>>,
-) -> PyResult<Vec<(String, String)>> {
+fn query_params_from_pydict(params: Option<&Bound<'_, PyDict>>) -> PyResult<Vec<(String, String)>> {
     let Some(params) = params else {
         return Ok(Vec::new());
     };
@@ -2814,7 +2811,9 @@ fn decode_remote_batch_search<'py>(
         list.append(tuple)?;
     }
     if offset != buf.len() {
-        return Err(py_runtime_err("trailing bytes in remote batch search response"));
+        return Err(py_runtime_err(
+            "trailing bytes in remote batch search response",
+        ));
     }
     Ok(list)
 }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -4843,7 +4843,10 @@ fn configure_routes(cfg: &mut web::ServiceConfig) {
             web::post().to(remove_vector_field_index),
         )
         .route("/upsert", web::post().to(upsert_records))
-        .route("/upsert_records_binary", web::post().to(upsert_records_binary))
+        .route(
+            "/upsert_records_binary",
+            web::post().to(upsert_records_binary),
+        )
         .route("/bulk_add_binary", web::post().to(bulk_add_binary))
         .route("/search", web::post().to(search))
         .route("/search_profile", web::post().to(search_profile))

--- a/src/storage/field_store.rs
+++ b/src/storage/field_store.rs
@@ -892,9 +892,7 @@ impl FieldStore {
             let map = self.apex_id_map.read();
             external_ids
                 .iter()
-                .filter_map(|&ext_id| {
-                    map.get(&ext_id).copied().filter(|&id| id != TOMBSTONE)
-                })
+                .filter_map(|&ext_id| map.get(&ext_id).copied().filter(|&id| id != TOMBSTONE))
                 .collect::<Vec<_>>()
         };
 
@@ -1069,9 +1067,7 @@ impl FieldStore {
         // Fast path: apex_id mmap point lookup
         let apex_id = {
             let map = self.apex_id_map.read();
-            map.get(&external_id)
-                .copied()
-                .filter(|&id| id != TOMBSTONE)
+            map.get(&external_id).copied().filter(|&id| id != TOMBSTONE)
         };
         if let Some(apex_id) = apex_id {
             if let Some(row) = table
@@ -1375,9 +1371,7 @@ impl FieldStore {
     fn filter_current_external_ids(&self, ids: Vec<u64>) -> Vec<u64> {
         let map = self.apex_id_map.read();
         ids.into_iter()
-            .filter(|&ext_id| {
-                map.get(&ext_id).is_some_and(|&id| id != TOMBSTONE)
-            })
+            .filter(|&ext_id| map.get(&ext_id).is_some_and(|&id| id != TOMBSTONE))
             .collect()
     }
 
@@ -2309,10 +2303,13 @@ mod tests {
         let store = FieldStore::new(tmp.path(), "fields").unwrap();
         let id = 1_000_000_000_000u64;
         store
-            .batch_store_at_ids(&[id], &[HashMap::from([(
-                "tag".to_string(),
-                serde_json::json!("sparse"),
-            )])])
+            .batch_store_at_ids(
+                &[id],
+                &[HashMap::from([(
+                    "tag".to_string(),
+                    serde_json::json!("sparse"),
+                )])],
+            )
             .unwrap();
 
         assert_eq!(store.apex_id_map.read().len(), 1);

--- a/src/storage/flat_mmap.rs
+++ b/src/storage/flat_mmap.rs
@@ -275,6 +275,24 @@ impl FlatMmap {
         }
     }
 
+    #[inline]
+    pub fn row_f32(&self, row: usize) -> Option<&[f32]> {
+        if self.dtype != VectorDtype::F32 || row >= self.n_vectors {
+            return None;
+        }
+        let start = row * self.dim;
+        Some(&self.as_slice()[start..start + self.dim])
+    }
+
+    #[inline]
+    pub fn row_f16_bits(&self, row: usize) -> Option<&[u16]> {
+        if self.dtype != VectorDtype::F16 || row >= self.n_vectors {
+            return None;
+        }
+        let start = row * self.dim;
+        Some(&self.as_f16_bits_slice()[start..start + self.dim])
+    }
+
     pub fn as_f32_cow(&self) -> Cow<'_, [f32]> {
         match (self.dtype, &self.mmap) {
             (VectorDtype::F32, _) => Cow::Borrowed(self.as_slice()),

--- a/src/storage/polarvec_mmap.rs
+++ b/src/storage/polarvec_mmap.rs
@@ -43,7 +43,7 @@
 //!   which has near-zero mean (RHT isotropy) → better candidate ranking.
 
 use crate::distance::DistanceMetric;
-use crate::storage::pq_mmap::rescore_exact;
+use crate::storage::pq_mmap::rescore_exact_with;
 use rand::rngs::SmallRng;
 use rand::{Rng, SeedableRng};
 use rayon::prelude::*;
@@ -275,8 +275,34 @@ impl PolarVecIndex {
         metric: DistanceMetric,
         oversample: usize,
     ) -> (Vec<u32>, Vec<f32>) {
+        self.search_with(query, k, metric, oversample, |idx| {
+            let base = idx as usize * self.dim;
+            let candidate = &f32_data[base..base + self.dim];
+            crate::distance::compute_distance_f32(query, candidate, metric)
+        })
+    }
+
+    pub fn search_with(
+        &self,
+        query: &[f32],
+        k: usize,
+        metric: DistanceMetric,
+        oversample: usize,
+        distance_at: impl FnMut(u32) -> f32,
+    ) -> (Vec<u32>, Vec<f32>) {
+        let candidates = self.search_candidates(query, k, metric, oversample);
+        rescore_exact_with(&candidates, k.min(self.n_vectors), metric, distance_at)
+    }
+
+    pub fn search_candidates(
+        &self,
+        query: &[f32],
+        k: usize,
+        metric: DistanceMetric,
+        oversample: usize,
+    ) -> Vec<u32> {
         if self.n_vectors == 0 || k == 0 {
-            return (vec![], vec![]);
+            return Vec::new();
         }
         let k = k.min(self.n_vectors);
         let n_candidates = (k * oversample).min(self.n_vectors);
@@ -326,7 +352,7 @@ impl PolarVecIndex {
             &[][..]
         };
 
-        let candidates: Vec<u32> = scan_topn(
+        scan_topn(
             &self.codes,
             self.n_vectors,
             self.bytes_per_vec,
@@ -341,10 +367,7 @@ impl PolarVecIndex {
         )
         .into_iter()
         .map(|(_, idx)| idx)
-        .collect();
-
-        // Pass 2: exact f32 re-rank
-        rescore_exact(&candidates, query, f32_data, self.dim, k, metric)
+        .collect()
     }
 
     /// Number of indexed vectors.

--- a/src/storage/pq_mmap.rs
+++ b/src/storage/pq_mmap.rs
@@ -140,8 +140,39 @@ impl PQIndex {
         metric: DistanceMetric,
         oversample: usize,
     ) -> (Vec<u32>, Vec<f32>) {
+        self.search_with(query, k, metric, oversample, |idx| {
+            let base = idx as usize * self.dim;
+            let candidate = &f32_data[base..base + self.dim];
+            crate::distance::compute_distance_f32(query, candidate, metric)
+        })
+    }
+
+    pub fn search_with(
+        &self,
+        query: &[f32],
+        k: usize,
+        metric: DistanceMetric,
+        oversample: usize,
+        distance_at: impl FnMut(u32) -> f32,
+    ) -> (Vec<u32>, Vec<f32>) {
+        let candidate_indices = self.search_candidates(query, k, metric, oversample);
+        rescore_exact_with(
+            &candidate_indices,
+            k.min(self.n_vectors),
+            metric,
+            distance_at,
+        )
+    }
+
+    pub fn search_candidates(
+        &self,
+        query: &[f32],
+        k: usize,
+        metric: DistanceMetric,
+        oversample: usize,
+    ) -> Vec<u32> {
         if self.n_vectors == 0 || k == 0 {
-            return (vec![], vec![]);
+            return Vec::new();
         }
         let k = k.min(self.n_vectors);
         let n_candidates = (k * oversample).min(self.n_vectors);
@@ -157,7 +188,7 @@ impl PQIndex {
         );
 
         // ADC scan: find top-N candidate indices
-        let candidate_indices = adc_scan_topn(
+        adc_scan_topn(
             &self.codes,
             self.n_vectors,
             self.n_subspaces,
@@ -165,10 +196,7 @@ impl PQIndex {
             &lut,
             n_candidates,
             metric.is_ascending(),
-        );
-
-        // Pass 2: exact f32 re-score
-        rescore_exact(&candidate_indices, query, f32_data, self.dim, k, metric)
+        )
     }
 
     /// Number of indexed vectors.
@@ -610,21 +638,43 @@ pub fn rescore_exact(
     k: usize,
     metric: DistanceMetric,
 ) -> (Vec<u32>, Vec<f32>) {
+    rescore_exact_with(candidates, k, metric, |idx| {
+        let base = idx as usize * dim;
+        let cand = unsafe { f32_data.get_unchecked(base..base + dim) };
+        match metric {
+            DistanceMetric::InnerProduct => simd::inner_product_f32(query, cand),
+            DistanceMetric::L2Squared => simd::l2_squared_f32(query, cand),
+            DistanceMetric::Cosine => simd::cosine_distance_f32(query, cand),
+            _ => crate::distance::compute_distance_f32(query, cand, metric),
+        }
+    })
+}
+
+pub fn rescore_exact_with(
+    candidates: &[u32],
+    k: usize,
+    metric: DistanceMetric,
+    mut distance_at: impl FnMut(u32) -> f32,
+) -> (Vec<u32>, Vec<f32>) {
+    match try_rescore_exact_with(candidates, k, metric, |idx| {
+        Ok::<f32, std::convert::Infallible>(distance_at(idx))
+    }) {
+        Ok(result) => result,
+        Err(never) => match never {},
+    }
+}
+
+pub fn try_rescore_exact_with<E>(
+    candidates: &[u32],
+    k: usize,
+    metric: DistanceMetric,
+    mut distance_at: impl FnMut(u32) -> std::result::Result<f32, E>,
+) -> std::result::Result<(Vec<u32>, Vec<f32>), E> {
     let ascending = metric.is_ascending();
     let mut exact: Vec<(f32, u32)> = candidates
         .iter()
-        .map(|&idx| {
-            let base = idx as usize * dim;
-            let cand = unsafe { f32_data.get_unchecked(base..base + dim) };
-            let dist = match metric {
-                DistanceMetric::InnerProduct => simd::inner_product_f32(query, cand),
-                DistanceMetric::L2Squared => simd::l2_squared_f32(query, cand),
-                DistanceMetric::Cosine => simd::cosine_distance_f32(query, cand),
-                _ => crate::distance::compute_distance_f32(query, cand, metric),
-            };
-            (dist, idx)
-        })
-        .collect();
+        .map(|&idx| distance_at(idx).map(|distance| (distance, idx)))
+        .collect::<std::result::Result<_, _>>()?;
 
     if ascending {
         exact.sort_unstable_by(|a, b| a.0.partial_cmp(&b.0).unwrap_or(Ordering::Equal));
@@ -635,7 +685,7 @@ pub fn rescore_exact(
 
     let indices = exact.iter().map(|e| e.1).collect();
     let dists = exact.iter().map(|e| e.0).collect();
-    (indices, dists)
+    Ok((indices, dists))
 }
 
 // ─── Distance helpers ─────────────────────────────────────────────────────────

--- a/src/storage/rabitq_mmap.rs
+++ b/src/storage/rabitq_mmap.rs
@@ -21,7 +21,7 @@
 //! with O(D log D) application complexity instead of O(D²).
 
 use crate::distance::DistanceMetric;
-use crate::storage::pq_mmap::rescore_exact;
+use crate::storage::pq_mmap::rescore_exact_with;
 use rand::rngs::SmallRng;
 use rand::{Rng, SeedableRng};
 use rayon::prelude::*;
@@ -167,8 +167,34 @@ impl RaBitQIndex {
         metric: DistanceMetric,
         oversample: usize,
     ) -> (Vec<u32>, Vec<f32>) {
+        self.search_with(query, k, metric, oversample, |idx| {
+            let base = idx as usize * self.dim;
+            let candidate = &f32_data[base..base + self.dim];
+            crate::distance::compute_distance_f32(query, candidate, metric)
+        })
+    }
+
+    pub fn search_with(
+        &self,
+        query: &[f32],
+        k: usize,
+        metric: DistanceMetric,
+        oversample: usize,
+        distance_at: impl FnMut(u32) -> f32,
+    ) -> (Vec<u32>, Vec<f32>) {
+        let candidates = self.search_candidates(query, k, metric, oversample);
+        rescore_exact_with(&candidates, k.min(self.n_vectors), metric, distance_at)
+    }
+
+    pub fn search_candidates(
+        &self,
+        query: &[f32],
+        k: usize,
+        metric: DistanceMetric,
+        oversample: usize,
+    ) -> Vec<u32> {
         if self.n_vectors == 0 || k == 0 {
-            return (vec![], vec![]);
+            return Vec::new();
         }
         let k = k.min(self.n_vectors);
         let n_candidates = (k * oversample).min(self.n_vectors);
@@ -187,7 +213,7 @@ impl RaBitQIndex {
         let lut = build_byte_lut(&q_rot, self.padded_dim);
 
         // Pass 1: binary ADC scan → top-N candidate indices
-        let candidates = binary_scan_topn(
+        binary_scan_topn(
             &self.codes,
             &self.norms,
             self.n_vectors,
@@ -197,10 +223,7 @@ impl RaBitQIndex {
             self.padded_dim,
             n_candidates,
             metric,
-        );
-
-        // Pass 2: exact f32 re-score
-        rescore_exact(&candidates, query, f32_data, self.dim, k, metric)
+        )
     }
 
     /// Number of indexed vectors.

--- a/src/storage/vector_store.rs
+++ b/src/storage/vector_store.rs
@@ -4,11 +4,12 @@
 //! changed only when the segment set changes, so normal ingestion remains a
 //! sequential append while compaction can replace selected segments.
 
-use crate::distance::DistanceMetric;
+use crate::distance::{compute_distance_f16, compute_distance_f32, DistanceMetric};
 use crate::error::{LynseError, Result};
 use crate::storage::approx_search::ApproxSearchConfig;
 use crate::storage::dtype::{encode_f32_slice_as_le_bytes, VectorDtype};
 use crate::storage::flat_mmap::FlatMmap;
+use crate::storage::pq_mmap::try_rescore_exact_with;
 use parking_lot::RwLock;
 use serde::{Deserialize, Serialize};
 use std::cmp::Ordering as CmpOrdering;
@@ -178,7 +179,9 @@ impl VectorStore {
             parsed
         } else {
             let legacy_path = collection_path.join("vectors.bin");
-            let bytes = std::fs::metadata(&legacy_path).map(|m| m.len()).unwrap_or(0);
+            let bytes = std::fs::metadata(&legacy_path)
+                .map(|m| m.len())
+                .unwrap_or(0);
             VectorManifest::legacy(if row_width == 0 { 0 } else { bytes / row_width })
         };
 
@@ -377,8 +380,7 @@ impl VectorStore {
         let mut manifest = self.manifest.write();
         let row_width = self.row_width();
         let append_to_current = manifest.segments.last().is_some_and(|segment| {
-            segment.rows.saturating_mul(row_width) + bytes.len() as u64
-                <= self.segment_target_bytes
+            segment.rows.saturating_mul(row_width) + bytes.len() as u64 <= self.segment_target_bytes
         });
 
         if manifest.segments.is_empty() || !append_to_current {
@@ -443,6 +445,19 @@ impl VectorStore {
     }
 
     fn ensure_mmaps(&self) -> Result<()> {
+        {
+            let manifest = self.manifest.read();
+            let cache = self.mmap_cache.read();
+            let ready = cache.len() == manifest.segments.len()
+                && cache
+                    .iter()
+                    .zip(manifest.segments.iter())
+                    .all(|(slot, segment)| segment.rows == 0 || slot.is_some());
+            if ready {
+                return Ok(());
+            }
+        }
+
         let manifest = self.manifest.read();
         let mut cache = self.mmap_cache.write();
         if cache.len() != manifest.segments.len() {
@@ -521,6 +536,107 @@ impl VectorStore {
         Ok(data)
     }
 
+    fn exact_distance_cached(
+        &self,
+        manifest: &VectorManifest,
+        cache: &[Option<FlatMmap>],
+        segment_ends: &[u64],
+        query: &[f32],
+        row: u64,
+        metric: DistanceMetric,
+    ) -> Result<f32> {
+        let segment_index = segment_ends.partition_point(|&end| end <= row);
+        let Some(segment) = manifest.segments.get(segment_index) else {
+            return Err(LynseError::InvalidArgument(format!(
+                "vector row {row} is out of bounds"
+            )));
+        };
+        let mmap = cache
+            .get(segment_index)
+            .and_then(Option::as_ref)
+            .ok_or_else(|| {
+                LynseError::Storage(format!(
+                    "vector segment {} is not memory mapped",
+                    segment.file
+                ))
+            })?;
+        let base = segment_index
+            .checked_sub(1)
+            .map(|index| segment_ends[index])
+            .unwrap_or(0);
+        let local_row = (row - base) as usize;
+        match self.dtype {
+            VectorDtype::F32 => mmap
+                .row_f32(local_row)
+                .map(|candidate| compute_distance_f32(query, candidate, metric))
+                .ok_or_else(|| {
+                    LynseError::Storage(format!(
+                        "vector row {row} is outside segment {}",
+                        segment.file
+                    ))
+                }),
+            VectorDtype::F16 => mmap
+                .row_f16_bits(local_row)
+                .map(|candidate| compute_distance_f16(query, candidate, metric))
+                .ok_or_else(|| {
+                    LynseError::Storage(format!(
+                        "vector row {row} is outside segment {}",
+                        segment.file
+                    ))
+                }),
+        }
+    }
+
+    pub fn exact_distance(&self, query: &[f32], row: u64, metric: DistanceMetric) -> Result<f32> {
+        if query.len() != self.dimension {
+            return Err(LynseError::DimensionMismatch {
+                expected: self.dimension,
+                got: query.len(),
+            });
+        }
+        self.ensure_mmaps()?;
+        let manifest = self.manifest.read();
+        let cache = self.mmap_cache.read();
+        let segment_ends: Vec<u64> = manifest
+            .segments
+            .iter()
+            .scan(0u64, |end, segment| {
+                *end = end.saturating_add(segment.rows);
+                Some(*end)
+            })
+            .collect();
+        self.exact_distance_cached(&manifest, &cache, &segment_ends, query, row, metric)
+    }
+
+    pub fn rescore_exact_candidates(
+        &self,
+        candidates: &[u32],
+        query: &[f32],
+        k: usize,
+        metric: DistanceMetric,
+    ) -> Result<(Vec<u32>, Vec<f32>)> {
+        if query.len() != self.dimension {
+            return Err(LynseError::DimensionMismatch {
+                expected: self.dimension,
+                got: query.len(),
+            });
+        }
+        self.ensure_mmaps()?;
+        let manifest = self.manifest.read();
+        let cache = self.mmap_cache.read();
+        let segment_ends: Vec<u64> = manifest
+            .segments
+            .iter()
+            .scan(0u64, |end, segment| {
+                *end = end.saturating_add(segment.rows);
+                Some(*end)
+            })
+            .collect();
+        try_rescore_exact_with(candidates, k, metric, |row| {
+            self.exact_distance_cached(&manifest, &cache, &segment_ends, query, row as u64, metric)
+        })
+    }
+
     pub fn read_rows(&self, rows: &[u64]) -> Result<Vec<f32>> {
         self.ensure_mmaps()?;
         let manifest = self.manifest.read();
@@ -530,14 +646,31 @@ impl VectorStore {
         for (segment, mmap) in manifest.segments.iter().zip(cache.iter()) {
             let end = base + segment.rows;
             if let Some(mmap) = mmap {
-                let data = mmap.as_f32_cow();
                 for (out, &row) in rows.iter().enumerate() {
                     if row >= base && row < end {
                         let local = (row - base) as usize;
-                        result[out * self.dimension..(out + 1) * self.dimension]
-                            .copy_from_slice(
-                                &data[local * self.dimension..(local + 1) * self.dimension],
-                            );
+                        let output = &mut result[out * self.dimension..(out + 1) * self.dimension];
+                        match self.dtype {
+                            VectorDtype::F32 => {
+                                output.copy_from_slice(mmap.row_f32(local).ok_or_else(|| {
+                                    LynseError::Storage(format!(
+                                        "vector row {row} is outside segment {}",
+                                        segment.file
+                                    ))
+                                })?);
+                            }
+                            VectorDtype::F16 => {
+                                let bits = mmap.row_f16_bits(local).ok_or_else(|| {
+                                    LynseError::Storage(format!(
+                                        "vector row {row} is outside segment {}",
+                                        segment.file
+                                    ))
+                                })?;
+                                for (value, &encoded) in output.iter_mut().zip(bits) {
+                                    *value = half::f16::from_bits(encoded).to_f32();
+                                }
+                            }
+                        }
                     }
                 }
             }
@@ -634,8 +767,7 @@ impl VectorStore {
         }
 
         let payload_end = journal.len() - 4;
-        let expected_checksum =
-            u32::from_le_bytes(journal[payload_end..].try_into().unwrap());
+        let expected_checksum = u32::from_le_bytes(journal[payload_end..].try_into().unwrap());
         let actual_checksum = crc32fast::hash(&journal[..payload_end]);
         if actual_checksum != expected_checksum {
             return Err(LynseError::Storage(
@@ -745,10 +877,10 @@ impl VectorStore {
             if group.is_empty() {
                 continue;
             }
-            let file = OpenOptions::new()
-                .read(true)
-                .write(true)
-                .open(self.collection_path.join(&manifest.segments[segment_index].file))?;
+            let file = OpenOptions::new().read(true).write(true).open(
+                self.collection_path
+                    .join(&manifest.segments[segment_index].file),
+            )?;
             for &(local_row, input_index) in group {
                 write_all_at(
                     &file,
@@ -826,7 +958,11 @@ impl VectorStore {
     ) -> (Vec<u64>, Vec<f32>) {
         results.sort_unstable_by(|a, b| {
             let order = a.1.partial_cmp(&b.1).unwrap_or(CmpOrdering::Equal);
-            let order = if metric.is_ascending() { order } else { order.reverse() };
+            let order = if metric.is_ascending() {
+                order
+            } else {
+                order.reverse()
+            };
             order.then_with(|| a.0.cmp(&b.0))
         });
         results.truncate(k);
@@ -1002,7 +1138,8 @@ impl VectorStore {
                 let mut compacted = Vec::with_capacity(live_rows * row_width);
                 for row in 0..segment.rows as usize {
                     if !deleted.contains(&row) {
-                        compacted.extend_from_slice(&source[row * row_width..(row + 1) * row_width]);
+                        compacted
+                            .extend_from_slice(&source[row * row_width..(row + 1) * row_width]);
                     }
                 }
                 let file = format!("{SEGMENT_DIR}/seg-{generation:020}-{index:06}.bin");
@@ -1017,7 +1154,10 @@ impl VectorStore {
             base = end;
         }
 
-        let compacted_rows: usize = new_segments.iter().map(|segment| segment.rows as usize).sum();
+        let compacted_rows: usize = new_segments
+            .iter()
+            .map(|segment| segment.rows as usize)
+            .sum();
         if compacted_rows != new_ids.len() {
             return Err(LynseError::Storage(format!(
                 "compacted vector rows ({compacted_rows}) do not match ID-map length ({})",


### PR DESCRIPTION
## Summary
- add blocking Rust/Python PR correctness checks and a label-triggered, non-blocking base/head performance comparison
- remove collection-sized external-ID rollback copies and full-corpus quantized-search materialization
- split mixed upserts into journaled updates plus appends while rebuilding ANN/quantized indexes at most once

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo test --locked` (183 passed, 2 ignored)
- [x] `python -m pytest tests/standard_tests tests/test_explicit_api_parameters.py -q` (480 passed, 4 skipped)
- [x] run Flat, PQ, RaBitQ, PolarVec, and indexed-upsert benchmark smoke tests
- [ ] add the `perf-check` label and inspect the base/head artifact and job summary